### PR TITLE
Publish addon update to version 2.2.2-alpha

### DIFF
--- a/addon/updates.json
+++ b/addon/updates.json
@@ -3,6 +3,10 @@
     "lockbox@mozilla.com": {
       "updates": [
         {
+          "version": "2.2.2-alpha",
+          "update_link": "https://github.com/mozilla-lockwise/lockwise-addon/releases/download/2.2.2-alpha/lockwise-signed-2.2.2-alpha.xpi"
+        },
+        {
           "version": "2.2.1-alpha",
           "update_link": "https://github.com/mozilla-lockwise/lockwise-addon/releases/download/2.2.1-alpha/lockwise-signed.xpi"
         },


### PR DESCRIPTION
Once merged this will go live on the website and then Firefox will check for updates and find the 2.2.2-alpha version, download it, and apply it.