### PR TITLE
Change Add-on Install Link based on Requesting Platform

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ github_username: mozilla-lockwise
 android_link: https://app.adjust.com/eu4xdqg?redirect=https://play.google.com/store/apps/details?id=mozilla.lockbox
 ios_link: https://app.adjust.com/eu4xdqg?redirect=https://itunes.apple.com/us/app/firefox-lockbox/id1314000270?mt=8
 addon_link: https://github.com/mozilla-lockwise/lockwise-addon/releases/download/2.2.2-alpha/lockwise-signed-2.2.2-alpha.xpi
+fx_link: https://www.mozilla.org/en-US/firefox/download/thanks/
 
 theme: minima
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -21,8 +21,8 @@ layout: home
           <a class="google-play-store" href="{{ site.android_link | escape }}">
             <img src="{{relativeBase}}assets/images/gps.svg" height="50" alt="Google Play Store">
           </a>
-          <a class="home__extension-link" href="{{ site.addon_link | escape }}">
-            <p class="button">Install for Firefox</p>
+          <a class="home__extension-link" href="{{ site.fx_link | escape }}">
+            <p class="button">Get Firefox</p>
           </a>
         </div>
         </div>
@@ -31,5 +31,22 @@ layout: home
         </div>
     </main>
     {%- include footer.html -%}
+    <script type="text/javascript">
+const addonBtn = document.querySelector("a.home__extension-link");
+const uaParams = /Firefox\/(.*)$/.exec(navigator.userAgent);
+if (uaParams) {
+  const ver = parseInt(uaParams[1].split("."[0]));
+  let link, text;
+  if (ver >= 67) {
+    link = "{{ site.addon_link | escape }}";
+    text = "Install for Firefox";
+  } else {
+    link = "{{ site.fx_link | escape }}";
+    text = "Upgrade Firefox";
+  }
+  addonBtn.href = link;
+  addonBtn.querySelector("p").textContent = text;
+}
+    </script>
   </body>
 </html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -31,22 +31,6 @@ layout: home
         </div>
     </main>
     {%- include footer.html -%}
-    <script type="text/javascript">
-const addonBtn = document.querySelector("a.home__extension-link");
-const uaParams = /Firefox\/(.*)$/.exec(navigator.userAgent);
-if (uaParams) {
-  const ver = parseInt(uaParams[1].split("."[0]));
-  let link, text;
-  if (ver >= 67) {
-    link = "{{ site.addon_link | escape }}";
-    text = "Install for Firefox";
-  } else {
-    link = "{{ site.fx_link | escape }}";
-    text = "Upgrade Firefox";
-  }
-  addonBtn.href = link;
-  addonBtn.querySelector("p").textContent = text;
-}
-    </script>
+    <script type="text/javascript" src="{{relativeBase}}assets/compatcheck.js"></script>
   </body>
 </html>

--- a/assets/compatcheck.js
+++ b/assets/compatcheck.js
@@ -1,15 +1,30 @@
-const addonBtn = document.querySelector("a.home__extension-link");
-const uaParams = /Firefox\/(.*)$/.exec(navigator.userAgent);
-if (uaParams) {
-    const ver = parseInt(uaParams[1].split("."[0]));
-    let link, text;
-    if (ver >= 67) {
-        link = "{{ site.addon_link | escape }}";
-        text = "Install for Firefox";
-    } else {
-        link = "{{ site.fx_link | escape }}";
-        text = "Upgrade Firefox";
+---
+---
+document.addEventListener("DOMContentLoaded", () => {
+    const CtoA = {
+        "addon": {
+            link: "{{ site.addon_link | escape }}",
+            text: "Install for Firefox",
+        },
+        "upgrade": {
+            link: "{{ site.fx_link | escape }}",
+            text: "Upgrade Firefox",
+        },
     }
-    addonBtn.href = link;
-    addonBtn.querySelector("p").textContent = text;
-}
+    const addonBtn = document.querySelector("a.home__extension-link");
+    const uaParams = /Firefox\/(.*)$/.exec(navigator.userAgent);
+    if (!uaParams) {
+        return;
+    }
+    const verParams = /(\d+).*$/.exec(uaParams[1]);
+    const ver = parseInt((verParams && verParams[1]) || "0");
+
+    let act;
+    if (ver >= 67) {
+        act = CtoA["addon"];
+    } else {
+        act = CtoA["upgrade"];
+    }
+    addonBtn.href = act.link;
+    addonBtn.querySelector("p").textContent = act.text;
+});

--- a/assets/compatcheck.js
+++ b/assets/compatcheck.js
@@ -1,0 +1,15 @@
+const addonBtn = document.querySelector("a.home__extension-link");
+const uaParams = /Firefox\/(.*)$/.exec(navigator.userAgent);
+if (uaParams) {
+    const ver = parseInt(uaParams[1].split("."[0]));
+    let link, text;
+    if (ver >= 67) {
+        link = "{{ site.addon_link | escape }}";
+        text = "Install for Firefox";
+    } else {
+        link = "{{ site.fx_link | escape }}";
+        text = "Upgrade Firefox";
+    }
+    addonBtn.href = link;
+    addonBtn.querySelector("p").textContent = text;
+}


### PR DESCRIPTION
Fixes #124
Connected to #125

This changes the install button based on the user's current browser:

* **Firefox 67 or higher** --> "Install for Firefox" (link to add-on)
![website-124-install](https://user-images.githubusercontent.com/757401/58661897-38e2fe00-82e6-11e9-9658-e17794b04e6e.png)

* **Firefox before 67** --> "Upgrade Firefox" (link to Fx install)
<img width="1127" alt="website-124-upgrade" src="https://user-images.githubusercontent.com/757401/58661911-40a2a280-82e6-11e9-879b-20874838fadb.png">

* **Not Firefox** --> "Get Firefox" (link to Fx install)
<img width="1096" alt="website-124-nonfx" src="https://user-images.githubusercontent.com/757401/58661923-47311a00-82e6-11e9-822d-5c76cd4fda8c.png">
